### PR TITLE
Issue 180 Typescript: Headless mode (run test) does not work 

### DIFF
--- a/common/src/codegen/playwright-typescript/templates/playwright-config.hbs
+++ b/common/src/codegen/playwright-typescript/templates/playwright-config.hbs
@@ -17,7 +17,7 @@ export default defineConfig({
   use: {
     trace: "on-first-retry",
 
-    headless: false,
+    headless: true,
     testIdAttribute: "data-testid",
   },
 

--- a/electron/worker/actions/runTest/runPlaywrightCommandBuilder.ts
+++ b/electron/worker/actions/runTest/runPlaywrightCommandBuilder.ts
@@ -59,7 +59,10 @@ export default class RunPlaywrightCommandBuilder implements ICommandBuilder {
     }
 
     const filterStr = this.buildFilter(settings.testCases);
-    const browserStr = settings.browser ? `--headed --project=${settings.browser}` : "";
+    const browserStr = settings.browser
+      ? `--headed --project=${settings.browser}`
+      : // Use chromium in headless mode
+        "--project=chromium";
 
     commands.push(
       // See https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test for more details about `dotnet test`


### PR DESCRIPTION
Issue #180  Specify headless in playwright config file; Use chromium by default for headless mode